### PR TITLE
add `--generate-transport` flag.

### DIFF
--- a/proto-gen-cli/src/main.rs
+++ b/proto-gen-cli/src/main.rs
@@ -40,8 +40,10 @@ struct TonicOpts {
     #[clap(short = 'c', long)]
     build_client: bool,
 
+    /// Whether to generate the ::connect and similar functions for tonic.
     #[clap(long)]
     generate_transport: bool,
+
     /// Type attributes to add.
     #[clap(long = "type-attribute", value_parser=KvValueParser)]
     type_attributes: Vec<(String, String)>,


### PR DESCRIPTION
This matches the `build_transport` configuration option, to allow generating generating clients for WASM too.

~I'll provide a matching patch for the proto.rs in ark~. Here's ark patch: https://github.com/EmbarkStudios/ark/pull/8713.