### PR TITLE
Fix handling of filename for keywords

### DIFF
--- a/proto-gen/src/gen.rs
+++ b/proto-gen/src/gen.rs
@@ -216,7 +216,9 @@ impl Module {
             Some(output)
         };
         if let Some(file) = self.file.as_ref() {
-            let file_location = self.location.join(format!("{}.rs", self.name));
+            let file_location = self
+                .location
+                .join(format!("{}.rs", self.proper_file_name()));
             // It's the same filename we don't need to move it but we need to edit it if it has
             // child modules.
             let is_same_file = &file_location == file;
@@ -260,6 +262,15 @@ impl Module {
     #[inline]
     fn get_name(&self) -> &str {
         self.name.as_str()
+    }
+
+    #[inline]
+    fn proper_file_name<'a>(&self) -> &str {
+        if self.name.starts_with("r#") {
+            &self.name[2..]
+        } else {
+            self.name.as_str()
+        }
     }
 }
 


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Fix filename for generated .rs file when it is names as a keyword. For example if any of the protos here https://github.com/googleapis/googleapis/tree/master/google/type is used the resulting file will be `src/proto_types/google/r#type.rs` which is not valid. After the changes here the file will instead be: `src/proto_types/google/type.rs`

