### PR TITLE
Fix for handling multiline code blocks in comments

### DIFF
--- a/proto-gen/CHANGELOG.md
+++ b/proto-gen/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#21](https://github.com/EmbarkStudios/proto-gen/pull/21) Fix for handling multiline code blocks in comments and make them ignored for doc tests.
 ## [0.2.3] - 2024-03-12
 ### Added
 - [PR#19](https://github.com/EmbarkStudios/proto-gen/pull/19) Added `-p, --prepend-header` option (default false) to prepend header indicating tool version in generated source file.


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Fix for cases where there exists multi-line code blocks in comments for proto files, e.g lines ending with `` ``` ``. These will become `` ```ignore `` at the beginning of the block so it's ignore for doc tests. Before this change these lines would be skipped and there could be insertions of `` ``` `` as well due to the existing detection of code-blocks.

