### PR TITLE
Fixes for the `--prepend-header` option

### DIFF
--- a/proto-gen/CHANGELOG.md
+++ b/proto-gen/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#22](https://github.com/EmbarkStudios/proto-gen/pull/22) Various fixes for the `--prepend-header` option and some cases for escaped doc-tests.
 ## [0.2.4] - 2024-03-12
 ### Fixed
 - [PR#21](https://github.com/EmbarkStudios/proto-gen/pull/21) Fix for handling multiline code blocks in comments and make them ignored for doc tests.

--- a/proto-gen/src/gen.rs
+++ b/proto-gen/src/gen.rs
@@ -225,6 +225,9 @@ impl Module {
                 a_borrow.get_name().cmp(b_borrow.get_name())
             });
             let mut output = String::new();
+            if gen_opts.prepend_header {
+                prepend_header(&mut output);
+            }
             for sorted_child in sortable_children {
                 let _ = output.write_fmt(format_args!(
                     "pub mod {};\n",

--- a/proto-gen/src/gen.rs
+++ b/proto-gen/src/gen.rs
@@ -127,7 +127,12 @@ fn clean_up_file_structure(out_dir: &Path, gen_opts: &GenOptions) -> Result<Stri
         .into_values()
         .collect::<Vec<Rc<RefCell<Module>>>>();
     // Linting, guh
-    let mut top_level_mod = "#![allow(clippy::doc_markdown, clippy::use_self)]\n".to_string();
+    let mut top_level_mod = String::new();
+    if gen_opts.prepend_header {
+        prepend_header(&mut top_level_mod);
+    }
+    top_level_mod.push_str("#![allow(clippy::doc_markdown, clippy::use_self)]\n");
+
     if let Some(toplevel_attribute) = &gen_opts.toplevel_attribute {
         top_level_mod.push_str(toplevel_attribute);
         top_level_mod.push('\n');


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Fixes for the `--prepend-header` option:
- Missing on top-level mod
- Missing on non top-level mod
- Missing on files where no filename change occurred

Also hides doctests on files where no filename change occurred.

