### PR TITLE
Attempt to fix build failure with cargo-deny-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          rust-version: "1.84.0"
 
   publish-check:
     name: Publish check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: EmbarkStudios/cargo-deny-action@v2
 
   publish-check:
     name: Publish check

--- a/deny.toml
+++ b/deny.toml
@@ -9,8 +9,7 @@ targets = [
 all-features = true
 
 [advisories]
-vulnerability = "deny"
-unmaintained = "warn"
+version = 2
 yanked = "deny"
 ignore = [
 ]
@@ -116,11 +115,8 @@ github = []
 
 [licenses]
 private = { ignore = true, registries = ["embark"] }
-unlicensed = "deny"
-allow-osi-fsf-free = "neither"
 # We want really high confidence when inferring licenses from text
 confidence-threshold = 0.92
-copyleft = "deny"
 allow = [
     # We skip our private workspace crates when doing license
     # checks, so you will need to assign a proper license


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

The release build of [0.2.9](https://github.com/EmbarkStudios/proto-gen/commit/634118eca415c44f2ad00d17b037c2495bf6c289) failed dur to this https://github.com/EmbarkStudios/proto-gen/actions/runs/12814491983/job/35731560503 which looks to be caused by the version in the `Cargo.lock` file being bumped to 4.

This attempts to fix this.